### PR TITLE
Fix issue with blast building on Linux where Python is always built.

### DIFF
--- a/blast.rb
+++ b/blast.rb
@@ -36,7 +36,7 @@ class Blast < Formula
   depends_on "lzo"      => :optional
   depends_on "pcre"     => :recommended
   depends_on :mysql     => :optional
-  depends_on :python if MacOS.version <= :snow_leopard
+  depends_on :python if MacOS.version <= :snow_leopard and OS.mac?
 
   def install
     # Fix error:


### PR DESCRIPTION
Added extra check to make sure Python is only built on Mac if required.  Maybe required option to build Python but most Linux distributions come with one centrally.
